### PR TITLE
refactor: update to 1.21.7

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,17 +5,17 @@ org.gradle.parallel=true
 # Fabric Properties
 # check these on https://fabricmc.net/develop
 
-minecraft_version=1.21
-yarn_mappings=1.21+build.2
-loader_version=0.15.11
+minecraft_version=1.21.7
+yarn_mappings=1.21.7+build.8
+loader_version=0.16.14
+loom_version=1.11-SNAPSHOT
 
 # Fabric API
-fabric_version=0.100.1+1.21
-
+fabric_version=0.129.0+1.21.7
 
 
 # Mod Properties
-mod_version=1.3
+mod_version=1.4
 maven_group=tr4nt.autoplantcrops
 archives_base_name=auto-plant-crops
 

--- a/src/main/java/tr4nt/autoplantcrops/Utils/Utils.java
+++ b/src/main/java/tr4nt/autoplantcrops/Utils/Utils.java
@@ -20,6 +20,7 @@ import tr4nt.autoplantcrops.config.ConfigFile;
 import tr4nt.autoplantcrops.mixin.CocoaBlockMixin;
 import tr4nt.autoplantcrops.mixin.CropBlockMixin;
 import tr4nt.autoplantcrops.mixin.NetherWartBlockMixin;
+import tr4nt.autoplantcrops.mixin.PlayerInventoryAccessor;
 import tr4nt.autoplantcrops.scheduler.Ticker;
 
 import java.sql.Date;
@@ -57,7 +58,7 @@ public class Utils {
             ItemStack stack = client.player.getInventory().getStack(i);
             if (getStackName(stack).equals(getStackName(item))) {
                 if (i <= 8) {
-                    client.player.getInventory().selectedSlot = i;
+                    ((PlayerInventoryAccessor) client.player.getInventory()).setSelectedSlot(i);
                     return;
                 } else {
                     int emptySlot = client.player.getInventory().getEmptySlot();
@@ -71,7 +72,7 @@ public class Utils {
                         client.interactionManager.clickSlot(0, i, 0, SlotActionType.QUICK_MOVE, client.player);
 
                         client.player.closeHandledScreen();
-                        client.player.getInventory().selectedSlot = emptySlot;
+                        ((PlayerInventoryAccessor) client.player.getInventory()).setSelectedSlot(emptySlot);
 
                         return;
                     }
@@ -88,7 +89,7 @@ public class Utils {
 
     public static void switchToSlot(MinecraftClient client, int slot) {
         assert client.player != null;
-        client.player.getInventory().selectedSlot = slot;
+        ((PlayerInventoryAccessor) client.player.getInventory()).setSelectedSlot(slot);
 
     }
 

--- a/src/main/java/tr4nt/autoplantcrops/event/ClientTickHandler.java
+++ b/src/main/java/tr4nt/autoplantcrops/event/ClientTickHandler.java
@@ -15,6 +15,7 @@ import tr4nt.autoplantcrops.AutoPlantCropsClient;
 import tr4nt.autoplantcrops.config.ConfigFile;
 
 import static tr4nt.autoplantcrops.Utils.Utils.*;
+import tr4nt.autoplantcrops.mixin.PlayerInventoryAccessor;
 
 public class ClientTickHandler implements ClientTickEvents.StartTick {
     private static long boneMealTick = tick();
@@ -31,7 +32,8 @@ public class ClientTickHandler implements ClientTickEvents.StartTick {
             BlockState state = client.player.getSteppingBlockState();
            Block block = state.getBlock();
            PlayerInventory inv = client.player.getInventory();
-           ItemStack item = inv.getStack(inv.selectedSlot);
+           int selectedSlot = ((PlayerInventoryAccessor) inv).getSelectedSlot();
+           ItemStack item = inv.getStack(selectedSlot);
            Block itemBlock = Block.getBlockFromItem(item.getItem());
 
            BlockPos upPos = client.player.getSteppingPos().up();
@@ -93,14 +95,14 @@ public class ClientTickHandler implements ClientTickEvents.StartTick {
                     if ((hoeing && finishedWaitForHoeingDelay) || (!hoeing && finishedWaitForDelay) )
                     {
 //                        boolean multiple = hoeing ? ConfigFile.getValue("farmLandMultiple").getAsBoolean() : ConfigFile.getValue("boneMealMultiple").getAsBoolean();
-                        queueInteraction(client, res, client.player.getInventory().selectedSlot, client.player.getInventory().getStack(client.player.getInventory().selectedSlot), false);
+                        queueInteraction(client, res, ((PlayerInventoryAccessor) client.player.getInventory()).getSelectedSlot(), client.player.getInventory().getStack(((PlayerInventoryAccessor) client.player.getInventory()).getSelectedSlot()), false);
                         if (!hoeing)  boneMealTick = tick();
                         if (hoeing) hoeingTick = tick();
                     }
 
                 } else
                 {
-                    queueInteraction(client, res, client.player.getInventory().selectedSlot, client.player.getInventory().getStack(client.player.getInventory().selectedSlot), false);
+                    queueInteraction(client, res, ((PlayerInventoryAccessor) client.player.getInventory()).getSelectedSlot(), client.player.getInventory().getStack(((PlayerInventoryAccessor) client.player.getInventory()).getSelectedSlot()), false);
                 }
             }
 

--- a/src/main/java/tr4nt/autoplantcrops/mixin/ClientPlayerInteractionMixin2.java
+++ b/src/main/java/tr4nt/autoplantcrops/mixin/ClientPlayerInteractionMixin2.java
@@ -24,6 +24,7 @@ import tr4nt.autoplantcrops.AutoPlantCropsClient;
 import tr4nt.autoplantcrops.config.ConfigFile;
 import tr4nt.autoplantcrops.event.BlockBreakEvent;
 import tr4nt.autoplantcrops.event.KeyInputHandler;
+import tr4nt.autoplantcrops.mixin.PlayerInventoryAccessor;
 
 import static tr4nt.autoplantcrops.Utils.Utils.*;
 
@@ -61,7 +62,7 @@ public class ClientPlayerInteractionMixin2
 //                HitResult hit = client.crosshairTarget;
 
 //                if (hit != null) {
-                int savedSlotValue = client.player.getInventory().selectedSlot;
+                int savedSlotValue = ((PlayerInventoryAccessor) client.player.getInventory()).getSelectedSlot();
                 ItemStack pickStack = null;
                 if (block instanceof CropBlock crop)
                 {

--- a/src/main/java/tr4nt/autoplantcrops/mixin/PlayerInventoryAccessor.java
+++ b/src/main/java/tr4nt/autoplantcrops/mixin/PlayerInventoryAccessor.java
@@ -1,0 +1,14 @@
+package tr4nt.autoplantcrops.mixin;
+
+import net.minecraft.entity.player.PlayerInventory;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(PlayerInventory.class)
+public interface PlayerInventoryAccessor {
+    @Accessor("selectedSlot")
+    int getSelectedSlot();
+
+    @Accessor("selectedSlot")
+    void setSelectedSlot(int slot);
+}

--- a/src/main/java/tr4nt/autoplantcrops/scheduler/Ticker.java
+++ b/src/main/java/tr4nt/autoplantcrops/scheduler/Ticker.java
@@ -8,6 +8,7 @@ import tr4nt.autoplantcrops.AutoPlantCropsClient;
 import tr4nt.autoplantcrops.config.ConfigFile;
 import tr4nt.autoplantcrops.event.KeyInputHandler;
 import tr4nt.autoplantcrops.event.PlaceBlock;
+import tr4nt.autoplantcrops.mixin.PlayerInventoryAccessor;
 
 import java.util.ArrayList;
 import java.util.function.Function;
@@ -42,7 +43,7 @@ public class Ticker implements ClientTickEvents.StartTick {
 
                     }
                     switchToItem(client, pickStack);
-                    if (getStackName(client.player.getInventory().getStack(client.player.getInventory().selectedSlot)).equals(getStackName(pickStack)))
+                    if (getStackName(client.player.getInventory().getStack(((PlayerInventoryAccessor) client.player.getInventory()).getSelectedSlot())).equals(getStackName(pickStack)))
                     {
                         PlaceBlock.placeSeed(clientt, res, plantMultiple);
                         if (ConfigFile.getValue("switchBackToSlot").getAsBoolean())

--- a/src/main/resources/auto-plant-crops.mixins.json
+++ b/src/main/resources/auto-plant-crops.mixins.json
@@ -6,7 +6,8 @@
     "ClientPlayerInteractionMixin2",
     "CocoaBlockMixin",
     "CropBlockMixin",
-    "NetherWartBlockMixin"
+    "NetherWartBlockMixin",
+    "PlayerInventoryAccessor"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
### This PR updates the mod to support Minecraft 1.21.7 and refactors the code to ensure compatibility.

**Key Changes**

- Dependency Upgrades: Updated Minecraft, Yarn, and Fabric API versions in gradle.properties.
- selectedSlot Compatibility: The PlayerInventory.selectedSlot field is now private. Implemented a Mixin Accessor (PlayerInventoryAccessor) to safely access this field, preventing crashes.
- Refactoring: Updated all direct calls to selectedSlot in ClientTickHandler, ClientPlayerInteractionMixin2, and Utils to use the new accessor.
- Mixin Registration: Added the new PlayerInventoryAccessor to auto-plant-crops.mixins.json to ensure it is applied correctly.

All changes have been tested, and the mod now runs correctly on Minecraft 1.21.7.